### PR TITLE
🧹 [code health improvement] Fix race condition in notification timeout

### DIFF
--- a/src/hooks/useNotification.ts
+++ b/src/hooks/useNotification.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { NotificationType } from '../components/Toast';
 
 interface UseNotificationReturn {
@@ -13,31 +13,45 @@ export function useNotification(): UseNotificationReturn {
     type: NotificationType;
   } | null>(null);
 
+  const timeoutRef = useRef<number | null>(null);
+
+  const clearNotificationTimeout = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
   const showNotification = useCallback(
     (message: string, type: NotificationType = 'info') => {
-      // Clear any existing notification
-      if (notification) {
-        setNotification(null);
-      }
+      // Clear any existing notification timeout
+      clearNotificationTimeout();
 
       // Show the new notification
       setNotification({ message, type });
 
       // Auto-hide after 3 seconds
-      setTimeout(() => {
+      timeoutRef.current = window.setTimeout(() => {
         setNotification(null);
+        timeoutRef.current = null;
       }, 3000);
     },
-    [notification]
+    [clearNotificationTimeout]
   );
 
   const hideNotification = useCallback(() => {
     setNotification(null);
-  }, []);
+    clearNotificationTimeout();
+  }, [clearNotificationTimeout]);
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => clearNotificationTimeout();
+  }, [clearNotificationTimeout]);
 
   return {
     notification,
     showNotification,
-    hideNotification
+    hideNotification,
   };
 }


### PR DESCRIPTION
### 🧹 [code health improvement] Fix race condition in notification timeout

#### 🎯 **What**
The code health issue addressed is a race condition in the `useNotification` hook where `setTimeout` was used to hide notifications without clearing previous timers.

#### 💡 **Why**
This improves maintainability and reliability by:
- Ensuring only the most recent notification's timer is active.
- Preventing older timers from accidentally hiding newer notifications.
- Cleaning up timeouts when the component unmounts to prevent potential memory leaks and state updates on unmounted components.
- Stabilizing the `showNotification` callback by removing the unnecessary dependency on the `notification` state.

#### ✅ **Verification**
- **Manual Code Review:** Confirmed the logic correctly uses `useRef` to track and clear timeouts.
- **TypeScript Review:** Verified that `window.setTimeout` and `window.clearTimeout` are used to ensure compatibility with browser-based types.
- **Build Check:** Attempted `npm run build`; although full installation failed in the environment, the source code was verified for syntax and logic correctness.

#### ✨ **Result**
The improvement achieved is a robust, predictable, and memory-safe notification hook that follows React best practices.

---
*PR created automatically by Jules for task [669670216708912818](https://jules.google.com/task/669670216708912818) started by @andrew362*