### PR TITLE
🔒 Fix .npmrc Data Loss and Insecure Config Overwrite

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -155,10 +155,31 @@ fn get_current_registry() -> Result<String, String> {
 fn set_registry(registry: String) -> Result<(), String> {
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
     let npmrc_path: PathBuf = [home_dir.to_str().unwrap(), ".npmrc"].iter().collect();
-    
-    // Write a simple npmrc content with the selected registry
-    fs::write(&npmrc_path, format!("registry={}", registry))
-        .map_err(|err| err.to_string())?;
+
+    // Sanitize the registry input to prevent configuration injection
+    let sanitized_registry = registry.replace('\n', "").replace('\r', "");
+
+    let mut lines: Vec<String> = if npmrc_path.exists() {
+        let content = fs::read_to_string(&npmrc_path).map_err(|err| err.to_string())?;
+        content.lines().map(|s| s.to_string()).collect()
+    } else {
+        Vec::new()
+    };
+
+    let mut found = false;
+    for line in lines.iter_mut() {
+        if line.starts_with("registry=") {
+            *line = format!("registry={}", sanitized_registry);
+            found = true;
+            break;
+        }
+    }
+
+    if !found {
+        lines.push(format!("registry={}", sanitized_registry));
+    }
+
+    fs::write(&npmrc_path, lines.join("\n") + "\n").map_err(|err| err.to_string())?;
     Ok(())
 }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This patch fixes a data loss and configuration injection vulnerability in the `.npmrc` management logic.

⚠️ **Risk:** The potential impact if left unfixed
Previously, whenever a user changed their registry through the app, all other settings in their `.npmrc` (like authentication tokens or email) were permanently deleted. Additionally, a malicious or malformed registry URL containing newlines could be used to inject arbitrary configuration lines into the `.npmrc` file.

🛡️ **Solution:** How the fix addresses the vulnerability
The `set_registry` function now follows a read-modify-write pattern:
- It reads the existing `.npmrc` content if it exists.
- It sanitizes the `registry` input by stripping `\n` and `\r` characters to prevent CRLF injection.
- It parses the file line-by-line, updating the `registry=` entry if found, or appending it at the end if not.
- All other configuration lines are preserved and written back to the file.


---
*PR created automatically by Jules for task [12122705946057361342](https://jules.google.com/task/12122705946057361342) started by @andrew362*