### PR TITLE
🧪 Add edge case tests for RegistrySelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,11 +17,15 @@
     "@tauri-apps/plugin-opener": "^2.2.6"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",
+    "vitest": "^2.1.8",
     "@tauri-apps/cli": "^2"
   }
 }

--- a/src/components/__tests__/RegistrySelector.test.tsx
+++ b/src/components/__tests__/RegistrySelector.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import RegistrySelector from '../RegistrySelector';
+
+describe('RegistrySelector', () => {
+  const mockRegistries = [
+    { name: 'npm', url: 'https://registry.npmjs.org/' },
+    { name: 'GitHub', url: 'https://npm.pkg.github.com' },
+  ];
+
+  const defaultProps = {
+    registries: mockRegistries,
+    selectedRegistry: '',
+    onRegistryChange: vi.fn(),
+    onUpdateClick: vi.fn(),
+    onRemoveRegistry: vi.fn(),
+  };
+
+  it('renders correctly with registries', () => {
+    render(<RegistrySelector {...defaultProps} />);
+
+    expect(screen.getByLabelText(/Select registry:/i)).toBeInTheDocument();
+    expect(screen.getByText('npm')).toBeInTheDocument();
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Manage Registries')).toBeInTheDocument();
+  });
+
+  it('hides "Manage Registries" section when registries array is empty', () => {
+    render(<RegistrySelector {...defaultProps} registries={[]} />);
+
+    expect(screen.queryByText('Manage Registries')).not.toBeInTheDocument();
+  });
+
+  it('disables update button when no registry is selected', () => {
+    render(<RegistrySelector {...defaultProps} selectedRegistry="" />);
+
+    const updateButton = screen.getByRole('button', { name: /update/i });
+    expect(updateButton).toBeDisabled();
+  });
+
+  it('enables update button when a registry is selected', () => {
+    render(<RegistrySelector {...defaultProps} selectedRegistry="https://registry.npmjs.org/" />);
+
+    const updateButton = screen.getByRole('button', { name: /update/i });
+    expect(updateButton).not.toBeDisabled();
+  });
+
+  it('calls onRegistryChange when a different registry is selected', () => {
+    render(<RegistrySelector {...defaultProps} />);
+
+    const select = screen.getByLabelText(/Select registry:/i);
+    fireEvent.change(select, { target: { value: 'https://npm.pkg.github.com' } });
+
+    expect(defaultProps.onRegistryChange).toHaveBeenCalledWith('https://npm.pkg.github.com');
+  });
+
+  it('calls onUpdateClick when update button is clicked', () => {
+    render(<RegistrySelector {...defaultProps} selectedRegistry="https://registry.npmjs.org/" />);
+
+    const updateButton = screen.getByRole('button', { name: /update/i });
+    fireEvent.click(updateButton);
+
+    expect(defaultProps.onUpdateClick).toHaveBeenCalled();
+  });
+
+  it('calls onRemoveRegistry when remove button is clicked', () => {
+    render(<RegistrySelector {...defaultProps} />);
+
+    const removeButtons = screen.getAllByText('Remove');
+    fireEvent.click(removeButtons[0]);
+
+    expect(defaultProps.onRemoveRegistry).toHaveBeenCalledWith('npm');
+  });
+
+  it('does not show remove button for "Global" registry', () => {
+    const registriesWithGlobal = [
+      ...mockRegistries,
+      { name: 'Global', url: 'https://registry.npmjs.org/' }
+    ];
+    render(<RegistrySelector {...defaultProps} registries={registriesWithGlobal} />);
+
+    const githubRegistryContainer = screen.getByText('GitHub').closest('div')?.parentElement;
+    const globalRegistryContainer = screen.getByText('Global').closest('div')?.parentElement;
+
+    expect(githubRegistryContainer).toContainElement(screen.getAllByText('Remove')[1]);
+    expect(globalRegistryContainer?.querySelector('button')).not.toBeInTheDocument();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts',
+  },
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `RegistrySelector` component, focusing on the edge case where no registries are present.

📊 **Coverage:**
- Verified that the "Manage Registries" section is hidden when the `registries` array is empty.
- Verified standard rendering with multiple registries.
- Verified that the "Update" button is correctly enabled/disabled based on selection.
- Verified interaction callbacks: `onRegistryChange`, `onUpdateClick`, and `onRemoveRegistry`.
- Verified special handling for the "Global" registry (no remove button).

✨ **Result:** Improved the reliability of the `RegistrySelector` component and established a testing foundation for the frontend using Vitest and React Testing Library.

---
*PR created automatically by Jules for task [15993609065331346579](https://jules.google.com/task/15993609065331346579) started by @andrew362*